### PR TITLE
Feat/linting interface naming

### DIFF
--- a/crates/lint/src/sol/info/interface_naming.rs
+++ b/crates/lint/src/sol/info/interface_naming.rs
@@ -12,6 +12,13 @@ declare_forge_lint!(
     "interface file names should be prefixed with 'I'"
 );
 
+declare_forge_lint!(
+    INTERFACE_NAMING,
+    Severity::Info,
+    "interface-naming",
+    "interface names should be prefixed with 'I'"
+);
+
 impl<'ast> EarlyLintPass<'ast> for InterfaceFileNaming {
     fn check_full_source_unit(
         &mut self,
@@ -54,6 +61,23 @@ impl<'ast> EarlyLintPass<'ast> for InterfaceFileNaming {
         // Emit if file contains ONLY interfaces. Emit only on the first interface.
         if let Some(span) = first_interface_span {
             ctx.emit(&INTERFACE_FILE_NAMING, span);
+        }
+    }
+
+    fn check_item_contract(&mut self, ctx: &LintContext, contract: &'ast ast::ItemContract<'ast>) {
+        if !ctx.is_lint_enabled(INTERFACE_NAMING.id()) {
+            return;
+        }
+
+        // Only check interfaces
+        if contract.kind != ast::ContractKind::Interface {
+            return;
+        }
+
+        // Check if interface name starts with 'I'
+        let name = contract.name.as_str();
+        if !name.starts_with('I') {
+            ctx.emit(&INTERFACE_NAMING, contract.name.span);
         }
     }
 }

--- a/crates/lint/src/sol/info/interface_naming.rs
+++ b/crates/lint/src/sol/info/interface_naming.rs
@@ -1,0 +1,59 @@
+use crate::{
+    linter::{EarlyLintPass, Lint, LintContext},
+    sol::{Severity, SolLint, info::InterfaceFileNaming},
+};
+
+use solar::ast::{self as ast};
+
+declare_forge_lint!(
+    INTERFACE_FILE_NAMING,
+    Severity::Info,
+    "interface-file-naming",
+    "interface file names should be prefixed with 'I'"
+);
+
+impl<'ast> EarlyLintPass<'ast> for InterfaceFileNaming {
+    fn check_full_source_unit(
+        &mut self,
+        ctx: &LintContext<'ast, '_>,
+        unit: &'ast ast::SourceUnit<'ast>,
+    ) {
+        if !ctx.is_lint_enabled(INTERFACE_FILE_NAMING.id()) {
+            return;
+        }
+
+        // Get first item in file and exit if the unit contains no items
+        let Some(first_item) = unit.items.first() else { return };
+
+        // Get file from first item
+        let file = ctx.session().source_map().lookup_source_file(first_item.span.lo());
+
+        // Get file name from file
+        let Some(file_name) = file.name.as_real().and_then(|path| path.file_name()?.to_str())
+        else {
+            return;
+        };
+
+        // If file name starts with 'I', skip lint
+        if file_name.starts_with('I') {
+            return;
+        }
+
+        let mut first_interface_span = None;
+        for item in unit.items.iter() {
+            if let ast::ItemKind::Contract(c) = &item.kind {
+                match c.kind {
+                    ast::ContractKind::Interface => {
+                        first_interface_span.get_or_insert(c.name.span);
+                    }
+                    _ => return, // Mixed file, skip lint
+                }
+            }
+        }
+
+        // Emit if file contains ONLY interfaces. Emit only on the first interface.
+        if let Some(span) = first_interface_span {
+            ctx.emit(&INTERFACE_FILE_NAMING, span);
+        }
+    }
+}

--- a/crates/lint/src/sol/info/mod.rs
+++ b/crates/lint/src/sol/info/mod.rs
@@ -22,7 +22,7 @@ mod multi_contract_file;
 use multi_contract_file::MULTI_CONTRACT_FILE;
 
 mod interface_naming;
-use interface_naming::INTERFACE_FILE_NAMING;
+use interface_naming::{INTERFACE_FILE_NAMING, INTERFACE_NAMING};
 
 register_lints!(
     (PascalCaseStruct, early, (PASCAL_CASE_STRUCT)),
@@ -33,5 +33,5 @@ register_lints!(
     (NamedStructFields, late, (NAMED_STRUCT_FIELDS)),
     (UnsafeCheatcodes, early, (UNSAFE_CHEATCODE_USAGE)),
     (MultiContractFile, early, (MULTI_CONTRACT_FILE)),
-    (InterfaceFileNaming, early, (INTERFACE_FILE_NAMING))
+    (InterfaceFileNaming, early, (INTERFACE_FILE_NAMING, INTERFACE_NAMING))
 );

--- a/crates/lint/src/sol/info/mod.rs
+++ b/crates/lint/src/sol/info/mod.rs
@@ -21,6 +21,9 @@ use unsafe_cheatcodes::UNSAFE_CHEATCODE_USAGE;
 mod multi_contract_file;
 use multi_contract_file::MULTI_CONTRACT_FILE;
 
+mod interface_naming;
+use interface_naming::INTERFACE_FILE_NAMING;
+
 register_lints!(
     (PascalCaseStruct, early, (PASCAL_CASE_STRUCT)),
     (MixedCaseVariable, early, (MIXED_CASE_VARIABLE)),
@@ -29,5 +32,6 @@ register_lints!(
     (Imports, early, (UNALIASED_PLAIN_IMPORT, UNUSED_IMPORT)),
     (NamedStructFields, late, (NAMED_STRUCT_FIELDS)),
     (UnsafeCheatcodes, early, (UNSAFE_CHEATCODE_USAGE)),
-    (MultiContractFile, early, (MULTI_CONTRACT_FILE))
+    (MultiContractFile, early, (MULTI_CONTRACT_FILE)),
+    (InterfaceFileNaming, early, (INTERFACE_FILE_NAMING))
 );

--- a/crates/lint/testdata/SoloInterfaces.sol
+++ b/crates/lint/testdata/SoloInterfaces.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-interface ISoloInterfaces {
+interface SoloInterfaces {
     function foo() external;
 }
 

--- a/crates/lint/testdata/SoloInterfaces.sol
+++ b/crates/lint/testdata/SoloInterfaces.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface ISoloInterfaces {
+    function foo() external;
+}
+
+interface I2 {
+    function foo() external;
+}
+
+interface I3 {
+    function foo() external;
+}
+

--- a/crates/lint/testdata/SoloInterfaces.stderr
+++ b/crates/lint/testdata/SoloInterfaces.stderr
@@ -1,0 +1,32 @@
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+  --> ROOT/testdata/SoloInterfaces.sol:LL:CC
+   |
+LL | interface ISoloInterfaces {
+   |           ^^^^^^^^^^^^^^^
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+  --> ROOT/testdata/SoloInterfaces.sol:LL:CC
+   |
+LL | interface I2 {
+   |           ^^
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+  --> ROOT/testdata/SoloInterfaces.sol:LL:CC
+   |
+LL | interface I3 {
+   |           ^^
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#multi-contract-file
+
+note[interface-file-naming]: interface file names should be prefixed with 'I'
+  --> ROOT/testdata/SoloInterfaces.sol:LL:CC
+   |
+LL | interface ISoloInterfaces {
+   |           ^^^^^^^^^^^^^^^
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#interface-file-naming
+

--- a/crates/lint/testdata/SoloInterfaces.stderr
+++ b/crates/lint/testdata/SoloInterfaces.stderr
@@ -1,8 +1,16 @@
+note[interface-naming]: interface names should be prefixed with 'I'
+  --> ROOT/testdata/SoloInterfaces.sol:LL:CC
+   |
+LL | interface SoloInterfaces {
+   |           ^^^^^^^^^^^^^^
+   |
+   = help: https://book.getfoundry.sh/reference/forge/forge-lint#interface-naming
+
 note[multi-contract-file]: prefer having only one contract, interface or library per file
   --> ROOT/testdata/SoloInterfaces.sol:LL:CC
    |
-LL | interface ISoloInterfaces {
-   |           ^^^^^^^^^^^^^^^
+LL | interface SoloInterfaces {
+   |           ^^^^^^^^^^^^^^
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#multi-contract-file
 
@@ -25,8 +33,8 @@ LL | interface I3 {
 note[interface-file-naming]: interface file names should be prefixed with 'I'
   --> ROOT/testdata/SoloInterfaces.sol:LL:CC
    |
-LL | interface ISoloInterfaces {
-   |           ^^^^^^^^^^^^^^^
+LL | interface SoloInterfaces {
+   |           ^^^^^^^^^^^^^^
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#interface-file-naming
 


### PR DESCRIPTION
Add 2 new linting rules : 
- Interfaces names should start with `I`
- Interface file names should start with `I`

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Enforce best practices.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
